### PR TITLE
Fix missing export error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import Canvas from './Canvas'
 import PaletteItem from './PaletteItem'
 import { useStore } from './store'
-import { BlockType } from './types'
+import type { BlockType } from './types'
 
 const blockTypes: { label: string; type: BlockType }[] = [
   { label: 'Prompt', type: 'prompt' },

--- a/frontend/src/Block.tsx
+++ b/frontend/src/Block.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties } from 'react'
 import { useDraggable } from '@dnd-kit/core'
-import { Block } from './types'
+import type { Block } from './types'
 
 interface Props {
   block: Block

--- a/frontend/src/PaletteItem.tsx
+++ b/frontend/src/PaletteItem.tsx
@@ -1,6 +1,6 @@
 import { useDraggable } from '@dnd-kit/core'
 import { CSSProperties } from 'react'
-import { BlockType } from './types'
+import type { BlockType } from './types'
 
 interface Props {
   type: BlockType

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { Block, BlockType } from './types'
+import type { Block, BlockType } from './types'
 
 interface State {
   blocks: Block[]


### PR DESCRIPTION
## Summary
- mark library imports as types only to avoid runtime import errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f4c6c79c4832e87212d2e8537b91c