### PR TITLE
Fix drag end type imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { DndContext, DragEndEvent } from '@dnd-kit/core'
+import { DndContext } from '@dnd-kit/core'
+import type { DragEndEvent } from '@dnd-kit/core'
 import Canvas from './Canvas'
 import PaletteItem from './PaletteItem'
 import { useStore } from './store'
@@ -18,8 +19,11 @@ export default function App() {
     const { over, active } = event
     if (over && over.id === 'canvas') {
       const type = (active.data.current as { type: BlockType }).type
-      const { x, y } = active.rect.current.translated
-      addBlock(type, x, y)
+      const rect = active.rect.current?.translated
+      if (rect) {
+        const { left, top } = rect
+        addBlock(type, left, top)
+      }
     }
   }
 

--- a/frontend/src/Block.tsx
+++ b/frontend/src/Block.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react'
+import type { CSSProperties } from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import type { Block } from './types'
 

--- a/frontend/src/PaletteItem.tsx
+++ b/frontend/src/PaletteItem.tsx
@@ -1,5 +1,5 @@
 import { useDraggable } from '@dnd-kit/core'
-import { CSSProperties } from 'react'
+import type { CSSProperties } from 'react'
 import type { BlockType } from './types'
 
 interface Props {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- fix type-only imports in various components
- handle drag end coordinates using left/top
- use vitest config in vite

## Testing
- `npx vitest run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f4e8edf2c832e8ac52bd033318a40