### PR TITLE
Fix drag-and-drop error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,15 +14,21 @@ const blockTypes: { label: string; type: BlockType }[] = [
 
 export default function App() {
   const addBlock = useStore((s) => s.addBlock)
+  const updateBlock = useStore((s) => s.updateBlock)
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { over, active } = event
     if (over && over.id === 'canvas') {
-      const type = (active.data.current as { type: BlockType }).type
       const rect = active.rect.current?.translated
-      if (rect) {
-        const { left, top } = rect
-        addBlock(type, left, top)
+      if (!rect) return
+      const { left, top } = rect
+
+      const data = active.data.current as { type?: BlockType; id?: string }
+
+      if (data?.type && active.id.toString().startsWith('palette-')) {
+        addBlock(data.type, left, top)
+      } else {
+        updateBlock(active.id.toString(), left, top)
       }
     }
   }

--- a/frontend/src/Block.tsx
+++ b/frontend/src/Block.tsx
@@ -9,6 +9,7 @@ interface Props {
 export default function BlockComponent({ block }: Props) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({
     id: block.id,
+    data: { id: block.id, type: block.type },
   })
 
   const style: CSSProperties = {


### PR DESCRIPTION
## Summary
- fix `handleDragEnd` logic to handle both new blocks and moving existing blocks
- attach draggable `data` to blocks so their id/type is available

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f5262c39c832e9dc552ef3fd43ac1