### PR TITLE
Update README with backend info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,26 @@ npm run dev
 ### Testing
 
 ```bash
-npm test
+npx vitest run
+```
+
+## Backend
+
+The `backend` directory exposes a small FastAPI application. You will need
+`fastapi`, `uvicorn`, `httpx`, `tenacity`, `respx` and `pytest` installed.
+
+Run the API from the repository root:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+You can override the n8n base URL with the optional `N8N_URL` environment
+variable. It defaults to `http://localhost:5678`.
+
+### Testing
+
+```bash
+pytest -q             # backend
+npx vitest run        # frontend
 ```


### PR DESCRIPTION
## Summary
- document packages, running and testing backend
- use `npx vitest run` for frontend tests

## Testing
- `pytest -q`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_683f810019b8832eb5186e800d8fe5e6