### PR TITLE
Add async context management for N8NClient

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,11 @@ from .n8n_client import N8NClient
 app = FastAPI()
 client = N8NClient()
 
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    """Close the underlying HTTP client on application shutdown."""
+    await client.client.aclose()
+
 @app.post("/deploy")
 async def deploy(flow: CanvasFlow):
     try:

--- a/backend/n8n_client.py
+++ b/backend/n8n_client.py
@@ -11,6 +11,14 @@ class N8NClient:
         self.base_url = base_url
         self.client = httpx.AsyncClient(base_url=base_url)
 
+    async def __aenter__(self) -> "N8NClient":
+        """Return the client instance when entering the context."""
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Close the underlying HTTP client when exiting the context."""
+        await self.client.aclose()
+
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
     async def create_workflow(self, name: str, nodes: Any) -> Dict[str, Any]:
         data = {"name": name, "nodes": nodes}


### PR DESCRIPTION
## Summary
- implement `__aenter__` and `__aexit__` to close `AsyncClient`
- ensure FastAPI shuts down the HTTP client properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f848a0138832e932c7f9230306a7e